### PR TITLE
Add customCacheDirectory option

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -17,6 +17,11 @@ NS_SWIFT_NAME(Options)
                       didFailWithError:(NSError *_Nullable *_Nullable)error;
 
 /**
+ * Optional, custom cache directory. Use when default one can not be accessed, e.g. in security environment.
+ */
+@property (nonatomic, strong) NSString *_Nullable customCacheDirectory;
+
+/**
  * The DSN tells the SDK where to send the events to. If this value is not provided, the SDK will
  * not send any events.
  */

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -81,7 +81,8 @@ SentryCrashIntegration ()
     self.scopeObserver =
         [[SentryCrashScopeObserver alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs];
 
-    [self startCrashHandler];
+    NSString *customDirectory = options.customCacheDirectory;
+    [self startCrashHandler:customDirectory];
 
     if (options.stitchAsyncCode) {
         [self.crashAdapter installAsyncHooks];
@@ -97,7 +98,7 @@ SentryCrashIntegration ()
     return kIntegrationOptionEnableCrashHandler;
 }
 
-- (void)startCrashHandler
+- (void)startCrashHandler:(NSString *)customCacheDirectory
 {
     void (^block)(void) = ^{
         BOOL canSendReports = NO;
@@ -114,7 +115,7 @@ SentryCrashIntegration ()
             canSendReports = YES;
         }
 
-        [installation install];
+        [installation install:customCacheDirectory];
 
         // We need to send the crashed event together with the crashed session in the same envelope
         // to have proper statistics in release health. To achieve this we need both synchronously

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.h
@@ -46,8 +46,9 @@
 
 /** Install this installation. Call this instead of -[SentryCrash install] to
  * install with everything needed for your particular backend.
+ * If you wish to use default cache directory, pass null
  */
-- (void)install;
+- (void)install:(NSString *)customCacheDirectory;
 
 /**
  * Call this instead of `-[SentryCrash uninstall]`.

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -282,9 +282,12 @@ SentryCrashInstallation ()
     }
 }
 
-- (void)install
+- (void)install:(NSString *)customCacheDirectory
 {
     SentryCrash *handler = [SentryCrash sharedInstance];
+    if (customCacheDirectory != NULL) {
+        handler.basePath = customCacheDirectory;
+    }
     @synchronized(handler) {
         g_crashHandlerData = self.crashHandlerData;
         handler.onCrash = crashCallback;

--- a/Sources/SentryCrash/Recording/SentryCrash.h
+++ b/Sources/SentryCrash/Recording/SentryCrash.h
@@ -58,6 +58,11 @@ static NSString *const SENTRYCRASH_REPORT_ATTACHMENTS_ITEM = @"attachments";
 /** Init SentryCrash instance with custom base path. */
 - (id)initWithBasePath:(NSString *)basePath;
 
+/** Optional, custom cache directory. Use when default one can not be accessed, e.g. in security environment.
+ * Default: null
+ */
+@property (nonatomic, readwrite, retain) NSString *basePath;
+
 /** A dictionary containing any info you'd like to appear in crash reports. Must
  * contain only JSON-safe data: NSString for keys, and NSDictionary, NSArray,
  * NSString, NSDate, and NSNumber for values.

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -56,7 +56,6 @@
 SentryCrash ()
 
 @property (nonatomic, readwrite, retain) NSString *bundleName;
-@property (nonatomic, readwrite, retain) NSString *basePath;
 @property (nonatomic, readwrite, assign) SentryCrashMonitorType monitoringWhenUninstalled;
 @property (nonatomic, readwrite, assign) BOOL monitoringFromUninstalledToRestore;
 @property (nonatomic, strong) SentryNSNotificationCenterWrapper *notificationCenter;


### PR DESCRIPTION
## :scroll: Description

This PR adds the ability for developers to specify a custom location for Sentry's cache location. 

## :bulb: Motivation and Context

This option is useful in scenarios where the application hosting Sentry doesn't have read/write permissions for the default cache location. This is particularly relevant for macOS applications running prelogin

## :green_heart: How did you test it?

Built a security agent plugin with the fork, specified the cache location, and ran the plugin at the login window

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
